### PR TITLE
Adding initial support for IKEv2 Site-to-Site VPNs

### DIFF
--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -253,7 +253,7 @@ if ( $vcVPN->exists('ipsec') ) {
   $genout .= "version 2.0\n";
   $genout .= "\n";
   $genout .= "config setup\n";
-  $genout .= "\tcharonstart=no\n";    # no need for charon unless we have ikev2
+  $genout .= "\tcharonstart=yes\n";
 
   #
   # Interfaces
@@ -864,6 +864,26 @@ if ( $vcVPN->exists('ipsec') ) {
           }
         }
         $genout .= "!\n";
+
+        #
+        # Get IKE version setting
+        #
+        my $key_exchange = $vcVPN->returnValue(
+          "ipsec ike-group $ike_group key-exchange");
+        if ( defined($key_exchange) ) {
+          if ($key_exchange eq 'auto') {
+            $genout .= "\tkeyexchange=ike\n";
+          }
+          elsif ($key_exchange eq 'ikev1') {
+            $genout .= "\tkeyexchange=ikev1\n";
+          }
+          elsif ($key_exchange eq 'ikev2') {
+            $genout .= "\tkeyexchange=ikev2\n";
+          }
+        }
+        else {
+          $genout .= "\tkeyexchange=ikev1\n";
+        }
 
         my $t_ikelifetime =
           $vcVPN->returnValue("ipsec ike-group $ike_group lifetime");

--- a/templates/vpn/ipsec/ike-group/node.tag/key-exchange/node.def
+++ b/templates/vpn/ipsec/ike-group/node.tag/key-exchange/node.def
@@ -1,0 +1,7 @@
+help: Key Exchange Version
+type: txt
+default: "ikev1"
+syntax:expression: $VAR(@) in "ike", "ikev1", "ikev2"; "must be ike, ikev1 or ikev2"
+val_help: ike; Automatically negoiatate Key Exchange version
+val_help: ikev1; Force IKEv1 for Key Exchange [DEFAULT]
+val_help: ikev2; Force IKEv2 for Key Exchange


### PR DESCRIPTION
This patch adds support for IKEv2 based Site-to-Site IPSec VPNs.

This is achieved by forcing StrongSwan's charon daemon which handles IKEv2 negotiations to start. To prevent unexpected behavior from the charon IKEv2 daemon, I've added code to automatically force IKEv1 negotiations instead of having StrongSwan decide on using IKEv1 or IKEv2 when a peer sends in a proposal. However, if the user chooses, they can have StrongSwan decide to automatically use either IKEv1 or IKEv2.
