### PR TITLE
Add support for DH groups 14-26

### DIFF
--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -855,10 +855,36 @@ if ( $vcVPN->exists('ipsec') ) {
                 $genout .= '-modp1024';
               } elsif ( $dh_group eq '5' ) {
                 $genout .= '-modp1536';
+              } elsif ( $dh_group eq '14' ) {
+                $genout .= '-modp2048';
+              } elsif ( $dh_group eq '15' ) {
+                $genout .= '-modp3072';
+              } elsif ( $dh_group eq '16' ) {
+                $genout .= '-modp4096';
+              } elsif ( $dh_group eq '17' ) {
+                $genout .= '-modp6144';
+              } elsif ( $dh_group eq '18' ) {
+                $genout .= '-modp8192';
+              } elsif ( $dh_group eq '19' ) {
+                $genout .= '-ecp256';
+              } elsif ( $dh_group eq '20' ) {
+                $genout .= '-ecp384';
+              } elsif ( $dh_group eq '21' ) {
+                $genout .= '-ecp521';
+              } elsif ( $dh_group eq '22' ) {
+                $genout .= '-modp1024s160';
+              } elsif ( $dh_group eq '23' ) {
+                $genout .= '-modp2048s224';
+              } elsif ( $dh_group eq '24' ) {
+                $genout .= '-modp2048s256';
+              } elsif ( $dh_group eq '25' ) {
+                $genout .= '-ecp192';
+              } elsif ( $dh_group eq '26' ) {
+                $genout .= '-ecp224';
               } elsif ( $dh_group ne '' ) {
                 vpn_die(["vpn","ipsec","site-to-site","peer",$peer,"tunnel", $tunnel],
                   "$vpn_cfg_err Invalid 'dh-group' $dh_group specified for "
-                  . "peer \"$peer\" $tunKeyword.  Only 2 or 5 accepted.\n");
+                  . "peer \"$peer\" $tunKeyword.  Only 2, 5, or 14 through 26 accepted.\n");
               }
             }
           }
@@ -1009,6 +1035,39 @@ if ( $vcVPN->exists('ipsec') ) {
           } elsif ( $pfs eq 'dh-group5' ) {
             $genout .= "\tpfs=yes\n";
             $genout .= "\tpfsgroup=modp1536\n";
+          } elsif ( $pfs eq 'dh-group14' ) {
+            $genout .= "\tpfs=yes\n";
+            $genout .= "\tpfsgroup=modp2048\n";
+          } elsif ( $pfs eq 'dh-group15' ) {
+            $genout .= "\tpfs=yes\n";
+            $genout .= "\tpfsgroup=modp3072\n";
+          } elsif ( $pfs eq 'dh-group16' ) {
+            $genout .= "\tpfs=yes\n";
+            $genout .= "\tpfsgroup=modp4096\n";
+          } elsif ( $pfs eq 'dh-group17' ) {
+            $genout .= "\tpfs=yes\n";
+            $genout .= "\tpfsgroup=modp6144\n";
+          } elsif ( $pfs eq 'dh-group18' ) {
+            $genout .= "\tpfs=yes\n";
+            $genout .= "\tpfsgroup=modp8192\n";
+          } elsif ( $pfs eq 'dh-group19' ) {
+            $genout .= "\tpfs=yes\n";
+            $genout .= "\tpfsgroup=ecp256\n";
+          } elsif ( $pfs eq 'dh-group20' ) {
+            $genout .= "\tpfs=yes\n";
+            $genout .= "\tpfsgroup=ecp384\n";
+          } elsif ( $pfs eq 'dh-group21' ) {
+            $genout .= "\tpfs=yes\n";
+            $genout .= "\tpfsgroup=ecp521\n";
+          # Omit groups 22-24 because strongSwan will fail
+          # to parse the generated config if the pfsgroup
+          # parameter is set to the keywords for these groups
+          } elsif ( $pfs eq 'dh-group25' ) {
+            $genout .= "\tpfs=yes\n";
+            $genout .= "\tpfsgroup=ecp192\n";
+          } elsif ( $pfs eq 'dh-group26' ) {
+            $genout .= "\tpfs=yes\n";
+            $genout .= "\tpfsgroup=ecp224\n";
           } else {
             $genout .= "\tpfs=no\n";
           }

--- a/templates/vpn/ipsec/esp-group/node.tag/pfs/node.def
+++ b/templates/vpn/ipsec/esp-group/node.tag/pfs/node.def
@@ -1,8 +1,18 @@
 help: ESP Perfect Forward Secrecy
 type: txt
 default: "enable"
-syntax:expression: $VAR(@) in "enable", "disable", "dh-group2", "dh-group5"; "must be enable, disable, dh-group2 or dh-group5"
+syntax:expression: $VAR(@) in "enable", "disable", "dh-group2", "dh-group5", "dh-group14", "dh-group15", "dh-group16", "dh-group17", "dh-group18", "dh-group19", "dh-group20", "dh-group21", "dh-group25", "dh-group26"; "must be enable, disable, dh-group2, dh-group5, dh-group14, dh-group15, dh-group16, dh-group17, dh-group18, dh-group19, dh-group20, dh-group21, dh-group25 or dh-group26"
 val_help: enable; Enable PFS. Use ike-group's dh-group (default)
-val_help: dh-group2; Enable PFS. Use Diffie-Hellman group 2
-val_help: dh-group5; Enable PFS. Use Diffie-Hellman group 5
+val_help: dh-group2; Enable PFS. Use Diffie-Hellman group 2 (modp1024)
+val_help: dh-group5; Enable PFS. Use Diffie-Hellman group 5 (modp1536)
+val_help: dh-group14; Enable PFS. Use Diffie-Hellman group 14 (modp2048)
+val_help: dh-group15; Enable PFS. Use Diffie-Hellman group 15 (modp3072)
+val_help: dh-group16; Enable PFS. Use Diffie-Hellman group 16 (modp4096)
+val_help: dh-group17; Enable PFS. Use Diffie-Hellman group 17 (modp6144)
+val_help: dh-group18; Enable PFS. Use Diffie-Hellman group 18 (modp8192)
+val_help: dh-group19; Enable PFS. Use Diffie-Hellman group 19 (ecp256)
+val_help: dh-group20; Enable PFS. Use Diffie-Hellman group 20 (ecp384)
+val_help: dh-group21; Enable PFS. Use Diffie-Hellman group 21 (ecp521)
+val_help: dh-group25; Enable PFS. Use Diffie-Hellman group 25 (ecp192)
+val_help: dh-group26; Enable PFS. Use Diffie-Hellman group 26 (ecp224)
 val_help: disable; Disable PFS

--- a/templates/vpn/ipsec/ike-group/node.tag/proposal/node.tag/dh-group/node.def
+++ b/templates/vpn/ipsec/ike-group/node.tag/proposal/node.tag/dh-group/node.def
@@ -1,5 +1,18 @@
 help: Diffie-Hellman (DH) key exchange group
 type: u32
-syntax:expression: ($VAR(@) == 2 || $VAR(@) == 5); "must be 2 or 5"
-val_help: 2; DH group 2
-val_help: 5; DH group 5
+syntax:expression: ($VAR(@) == 2 || $VAR(@) == 5 || ($VAR(@) >= 14 && $VAR(@) <= 26)); "must be 2, 5 or 14 through 26"
+val_help: 2; DH group 2 (modp1024)
+val_help: 5; DH group 5 (modp1536)
+val_help: 14; DH group 14 (modp2048)
+val_help: 15; DH group 15 (modp3072)
+val_help: 16; DH group 16 (modp4096)
+val_help: 17; DH group 17 (modp6144)
+val_help: 18; DH group 18 (modp8192)
+val_help: 19; DH group 19 (ecp256)
+val_help: 20; DH group 20 (ecp384)
+val_help: 21; DH group 21 (ecp521)
+val_help: 22; DH group 22 (modp1024s160)
+val_help: 23; DH group 23 (modp2048s224)
+val_help: 24; DH group 24 (modp2048s256)
+val_help: 25; DH group 25 (ecp192)
+val_help: 26; DH group 26 (ecp224)


### PR DESCRIPTION
Here's a patch to add support for additional Diffie-Hellman groups.

I've tested to ensure that IKE SAs establish successfully with each of the new groups between two VyOS 1.0.3 instances. The only anomaly is that strongSwan fails to parse the generated ipsec.conf if the `pfsgroup` parameter is set to the [keyword](http://wiki.strongswan.org/projects/strongswan/wiki/IKEv1CipherSuites) for groups 22-24, so I've omitted them from the `esp-group pfs` node template.
