### PR TITLE
Bug 220: Add support for SHA2 hashes

### DIFF
--- a/templates/vpn/ipsec/esp-group/node.tag/proposal/node.tag/hash/node.def
+++ b/templates/vpn/ipsec/esp-group/node.tag/proposal/node.tag/hash/node.def
@@ -1,6 +1,9 @@
 help: Hash algorithm
 type: txt
 default: "sha1"
-syntax:expression: $VAR(@) in "md5", "sha1"; "must be md5 or sha1"
+syntax:expression: $VAR(@) in "md5", "sha1", "sha256", "sha384", "sha512"; "must be md5, sha1, sha256, sha384 or sha512"
 val_help: md5; MD5 hash
 val_help: sha1; SHA1 hash (default)
+val_help: sha256; SHA2-256 hash
+val_help: sha384; SHA2-384 hash
+val_help: sha512; SHA2-512 hash

--- a/templates/vpn/ipsec/ike-group/node.tag/proposal/node.tag/hash/node.def
+++ b/templates/vpn/ipsec/ike-group/node.tag/proposal/node.tag/hash/node.def
@@ -1,6 +1,9 @@
 help: Hash algorithm
 type: txt
 default: "sha1"
-syntax:expression: $VAR(@) in "md5", "sha1"; "must be md5 or sha1"
+syntax:expression: $VAR(@) in "md5", "sha1", "sha256", "sha384", "sha512"; "must be md5, sha1, sha256, sha384 or sha512"
 val_help: md5; MD5 hash
 val_help: sha1; SHA1 hash (default)
+val_help: sha256; SHA2-256 hash
+val_help: sha384; SHA2-384 hash
+val_help: sha512; SHA2-512 hash


### PR DESCRIPTION
Here's a patch to add support for SHA2 hashes for both IKE and ESP.

I've successfully tested all three new hashes with both IKE and ESP between two VyOS 1.0.3 instances.
