### PR TITLE
Remove automatic IKE version negoiation.

### DIFF
--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -897,13 +897,10 @@ if ( $vcVPN->exists('ipsec') ) {
         my $key_exchange = $vcVPN->returnValue(
           "ipsec ike-group $ike_group key-exchange");
         if ( defined($key_exchange) ) {
-          if ($key_exchange eq 'auto') {
-            $genout .= "\tkeyexchange=ike\n";
-          }
-          elsif ($key_exchange eq 'ikev1') {
+          if ($key_exchange eq 'ikev1') {
             $genout .= "\tkeyexchange=ikev1\n";
           }
-          elsif ($key_exchange eq 'ikev2') {
+          if ($key_exchange eq 'ikev2') {
             $genout .= "\tkeyexchange=ikev2\n";
           }
         }

--- a/templates/vpn/ipsec/ike-group/node.tag/key-exchange/node.def
+++ b/templates/vpn/ipsec/ike-group/node.tag/key-exchange/node.def
@@ -1,7 +1,6 @@
 help: Key Exchange Version
 type: txt
 default: "ikev1"
-syntax:expression: $VAR(@) in "ike", "ikev1", "ikev2"; "must be ike, ikev1 or ikev2"
-val_help: ike; Automatically negoiatate Key Exchange version
-val_help: ikev1; Force IKEv1 for Key Exchange [DEFAULT]
-val_help: ikev2; Force IKEv2 for Key Exchange
+syntax:expression: $VAR(@) in "ikev1", "ikev2"; "must be ikev1 or ikev2"
+val_help: ikev1; Use IKEv1 for Key Exchange [DEFAULT]
+val_help: ikev2; Use IKEv2 for Key Exchange


### PR DESCRIPTION
According to the strongSwan 4.5.x documentation, the keyexchange configuration value "ike" is a synonym to "ikev2".

In strongSwan 5.0.0 however, the configuration value "ike" will try to negoiate IKEv2 connections but will accept IKEv1 connections if the remote peer sends an IKEv1 request.

The previous behavior where IKEv1 will be unconditionally set is not affected by this change.
