### PR TITLE
Bug 197: Add back support for groups 22-24 for phase2 pfs

### DIFF
--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -1059,9 +1059,15 @@ if ( $vcVPN->exists('ipsec') ) {
           } elsif ( $pfs eq 'dh-group21' ) {
             $genout .= "\tpfs=yes\n";
             $genout .= "\tpfsgroup=ecp521\n";
-          # Omit groups 22-24 because strongSwan will fail
-          # to parse the generated config if the pfsgroup
-          # parameter is set to the keywords for these groups
+          } elsif ( $pfs eq 'dh-group22' ) {
+            $genout .= "\tpfs=yes\n";
+            $genout .= "\tpfsgroup=modp1024s160\n";
+          } elsif ( $pfs eq 'dh-group23' ) {
+            $genout .= "\tpfs=yes\n";
+            $genout .= "\tpfsgroup=modp2048s224\n";
+          } elsif ( $pfs eq 'dh-group24' ) {
+            $genout .= "\tpfs=yes\n";
+            $genout .= "\tpfsgroup=modp2048s256\n";
           } elsif ( $pfs eq 'dh-group25' ) {
             $genout .= "\tpfs=yes\n";
             $genout .= "\tpfsgroup=ecp192\n";

--- a/templates/vpn/ipsec/esp-group/node.tag/pfs/node.def
+++ b/templates/vpn/ipsec/esp-group/node.tag/pfs/node.def
@@ -1,7 +1,7 @@
 help: ESP Perfect Forward Secrecy
 type: txt
 default: "enable"
-syntax:expression: $VAR(@) in "enable", "disable", "dh-group2", "dh-group5", "dh-group14", "dh-group15", "dh-group16", "dh-group17", "dh-group18", "dh-group19", "dh-group20", "dh-group21", "dh-group25", "dh-group26"; "must be enable, disable, dh-group2, dh-group5, dh-group14, dh-group15, dh-group16, dh-group17, dh-group18, dh-group19, dh-group20, dh-group21, dh-group25 or dh-group26"
+syntax:expression: $VAR(@) in "enable", "disable", "dh-group2", "dh-group5", "dh-group14", "dh-group15", "dh-group16", "dh-group17", "dh-group18", "dh-group19", "dh-group20", "dh-group21", "dh-group22", "dh-group23", "dh-group24", "dh-group25", "dh-group26"; "must be enable, disable, dh-group2, dh-group5, dh-group14, dh-group15, dh-group16, dh-group17, dh-group18, dh-group19, dh-group20, dh-group21, dh-group22, dh-group23, dh-group24, dh-group25 or dh-group26"
 val_help: enable; Enable PFS. Use ike-group's dh-group (default)
 val_help: dh-group2; Enable PFS. Use Diffie-Hellman group 2 (modp1024)
 val_help: dh-group5; Enable PFS. Use Diffie-Hellman group 5 (modp1536)
@@ -13,6 +13,9 @@ val_help: dh-group18; Enable PFS. Use Diffie-Hellman group 18 (modp8192)
 val_help: dh-group19; Enable PFS. Use Diffie-Hellman group 19 (ecp256)
 val_help: dh-group20; Enable PFS. Use Diffie-Hellman group 20 (ecp384)
 val_help: dh-group21; Enable PFS. Use Diffie-Hellman group 21 (ecp521)
+val_help: dh-group22; Enable PFS. Use Diffie-Hellman group 22 (modp1024s160)
+val_help: dh-group23; Enable PFS. Use Diffie-Hellman group 23 (modp2048s224)
+val_help: dh-group24; Enable PFS. Use Diffie-Hellman group 24 (modp2048s256)
 val_help: dh-group25; Enable PFS. Use Diffie-Hellman group 25 (ecp192)
 val_help: dh-group26; Enable PFS. Use Diffie-Hellman group 26 (ecp224)
 val_help: disable; Disable PFS


### PR DESCRIPTION
Works for me between two helium instances. Depends on [PR #2 on vyatta-strongswan](https://github.com/vyos/vyatta-strongswan/pull/2). See also [PR #2](https://github.com/vyos/vyatta-cfg-vpn/pull/2).
