### PR TITLE
Initial MOBIKE Configuration Support

### DIFF
--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -910,6 +910,27 @@ if ( $vcVPN->exists('ipsec') ) {
         else {
           $genout .= "\tkeyexchange=ikev1\n";
         }
+        
+        #
+        # Allow the user to disable MOBIKE for IKEv2 connections
+        #
+        my $mob_ike = $vcVPN->returnValue(
+          "ipsec ike-group $ike_group mobike");
+
+        if ( defined($mob_ike) ) {
+          if ( defined($key_exchange) && $key_exchange eq 'ikev2' ) {
+            if ($mob_ike eq 'enabled') {
+                $genout .= "\tmobike=yes\n";
+            }
+            if ($mob_ike eq 'disabled') {
+                $genout .= "\tmobike=no\n";
+            }
+          }
+          else {
+            vpn_die(["vpn","ipsec","ike-group", $ike_group, "mobike"], 
+            "$vpn_cfg_err MOBIKE is only valid for IKEv2 configurations.\n");
+          }
+        }
 
         my $t_ikelifetime =
           $vcVPN->returnValue("ipsec ike-group $ike_group lifetime");

--- a/templates/vpn/ipsec/ike-group/node.tag/mobike/node.def
+++ b/templates/vpn/ipsec/ike-group/node.tag/mobike/node.def
@@ -1,0 +1,5 @@
+help: Enable MOBIKE Support. MOBIKE is only valid for IKEv2 configurations.
+type: txt
+syntax:expression: $VAR(@) in "enabled", "disabled"; "must be enabled or disabled"
+val_help: enabled; Enable MOBIKE ([DEFAULT] if IKEv2)
+val_help: disabled; Disable MOBIKE 


### PR DESCRIPTION
For IKEv2, there is support for MOBIKE which basically allows IPSec connections to roam from interface to interface. When MOBIKE is used, the IKE negoiation phase uses UDP port 4500 rather than using proto-51.

In strongSwan 4.5.x MOBIKE is automatically enabled for IKEv2 connections. We expose the ability to enable/disable MOBIKE to the user.
