### PR TITLE
Add support for IPsec phase 1 ID of IPv4 address format

### DIFF
--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -591,7 +591,13 @@ if ( $vcVPN->exists('ipsec') ) {
           $genout .= "\tleft=$lip\n";
           $leftsourceip = "\tleftsourceip=$lip\n";
         }
-        $genout .= "\tleftid=$authid\n" if defined $authid;
+        if ( defined($authid) ) {
+          if ( $authid =~ m/^\@/ ) {
+            $genout .= "\tleftid=\"$authid\"\n";
+          } else {
+            $genout .= "\tleftid=$authid\n";
+          }
+        }
       }
 
       # @SM Todo: must have explicit settings for VTI.
@@ -601,9 +607,13 @@ if ( $vcVPN->exists('ipsec') ) {
       if ( $peer =~ /^\@/ ) {
 
         # peer is an "ID"
-        $rightid  = $peer;
+        if ( defined($authremoteid) ) {
+          $rightid = $authremoteid;
+        } else {
+          $rightid = $peer;
+        }
         $any_peer = 1;
-      } elsif ($authremoteid) {
+      } elsif ( defined($authremoteid) ) {
         $rightid = $authremoteid;
       }
       if ( ( $peer eq 'any' )
@@ -621,7 +631,13 @@ if ( $vcVPN->exists('ipsec') ) {
         $right = $peer;
       }
       $genout .= "\tright=$right\n";
-      $genout .= "\trightid=\"$rightid\"\n" if ( defined($rightid) );
+      if ( defined($rightid) ) {
+        if ( $rightid =~ m/^\@/ ) {
+          $genout .= "\trightid=\"$rightid\"\n";
+        } else {
+          $genout .= "\trightid=$rightid\n";
+        }
+      }
       if ($any_peer) {
         $genout .= "\trekey=no\n";
       }

--- a/templates/vpn/ipsec/site-to-site/peer/node.tag/authentication/id/node.def
+++ b/templates/vpn/ipsec/site-to-site/peer/node.tag/authentication/id/node.def
@@ -2,4 +2,5 @@ help: ID for peer authentication
 type: txt
 syntax:expression: pattern $VAR(@) "^[[:print:]]+"
                      ; "invalid ID \"$VAR(@)\""
+val_help: ipv4; ID used for peer authentication
 val_help: @<text>; ID used for peer authentication

--- a/templates/vpn/ipsec/site-to-site/peer/node.tag/authentication/remote-id/node.def
+++ b/templates/vpn/ipsec/site-to-site/peer/node.tag/authentication/remote-id/node.def
@@ -2,4 +2,5 @@ help: ID for remote authentication
 type: txt
 syntax:expression: pattern $VAR(@) "^[[:print:]]+"
                      ; "invalid ID \"$VAR(@)\""
+val_help: ipv4; ID used for peer authentication
 val_help: @<text>; ID used for peer authentication


### PR DESCRIPTION
Some IPsec VPN router commonly used in Japan don't use Global IPv4 address as IPsec phase 1 ID.
Moreover they cannot set IPsec phase 1 ID as FQDN/USER_FQDN format (like "@foo") when Main mode.

This patch add support for IPsec phase 1 ID of IPv4 address format like below.

vyos@vyos# set vpn ipsec site-to-site peer @foo authentication remote-id 192.168.1.1

I want you to merge because there are a lot of Japanese people who be saved this problem is fixed.
