### PR TITLE
vyatta-cfg-vpn: add libnfnetlink-dev to build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: vyatta-cfg-vpn
 Section: contrib/net
 Priority: extra
-Maintainer: Vyatta Package Maintainers <maintainers@vyatta.com>
+Maintainer: Vyatta Package Maintainers <maintainers@vyos.net>
 Build-Depends: debhelper (>= 5), autotools-dev, libnfnetlink-dev
 Standards-Version: 3.7.2
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: vyatta-cfg-vpn
 Section: contrib/net
 Priority: extra
 Maintainer: Vyatta Package Maintainers <maintainers@vyatta.com>
-Build-Depends: debhelper (>= 5), autotools-dev
+Build-Depends: debhelper (>= 5), autotools-dev, libnfnetlink-dev
 Standards-Version: 3.7.2
 
 Package: vyatta-cfg-vpn


### PR DESCRIPTION
Add libnfnetlink-dev to the list of build dependencies, required for
compiling src/cfgcti.

Bug #317 http://bugzilla.vyos.net/show_bug.cgi?id=317
