### PR TITLE
Ikev2 reauth option

### DIFF
--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -815,7 +815,7 @@ if ($vcVPN->exists('ipsec')) {
                 #
                 # Get ikev2-reauth configuration
                 #
-                if ((defined($key_exchange) && ($key_exchange eq 'ikev2')) {
+                if ((defined($key_exchange)) && ($key_exchange eq 'ikev2')) {
                     my $ikev2_tunnel_reauth = $vcVPN->returnValue("ipsec site-to-site peer $peer ikev2-reauth");
 
                     if ((defined($ikev2_tunnel_reauth)) && ($ikev2_tunnel_reauth ne 'inherit')) {

--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -813,6 +813,25 @@ if ($vcVPN->exists('ipsec')) {
                 }
 
                 #
+                # Get ikev2-reauth configuration
+                #
+                if ((defined($key_exchange) && ($key_exchange eq 'ikev2')) {
+                    my $ikev2_tunnel_reauth = $vcVPN->returnValue("ipsec site-to-site peer $peer ikev2-reauth");
+
+                    if ((defined($ikev2_tunnel_reauth)) && ($ikev2_tunnel_reauth ne 'inherit')) {
+                        $genout .= "\treauth=$ikev2_tunnel_reauth\n";
+                    } else {
+                        my $ikev2_group_reauth = $vcVPN->returnValue("ipsec ike-group $ike_group ikev2-reauth");
+                        if (defined($ikev2_group_reauth)) {
+                            $genout .= "\treauth=$ikev2_group_reauth\n";
+                        } else {
+                            $genout .= "\treauth=no\n";
+                        }
+                    }
+
+                }
+
+                #
                 # Allow the user to disable MOBIKE for IKEv2 connections
                 #
                 my $mob_ike = $vcVPN->returnValue("ipsec ike-group $ike_group mobike");

--- a/templates/vpn/ipsec/ike-group/node.tag/ikev2-reauth/node.def
+++ b/templates/vpn/ipsec/ike-group/node.tag/ikev2-reauth/node.def
@@ -1,0 +1,6 @@
+help: Re-authentication of the remote peer during an IKE re-key.  IKEv2 option only
+type: txt
+default: "no"
+syntax:expression: $VAR(@) in "yes", "no"; "must be yes or no (Default)"
+val_help: yes; Enable remote host re-autentication during an IKE rekey. Currently broken due to a strong swan bug
+val_help: no; Disable remote host re-authenticaton during an IKE rekey. (Default)

--- a/templates/vpn/ipsec/site-to-site/peer/node.tag/ikev2-reauth/node.def
+++ b/templates/vpn/ipsec/site-to-site/peer/node.tag/ikev2-reauth/node.def
@@ -1,0 +1,7 @@
+help: Re-authentication of the remote peer during an IKE re-key.  IKEv2 option only
+type: txt
+default: "inherit"
+syntax:expression: $VAR(@) in "yes", "no"; "must be yes, no or inherit (Default)"
+val_help: yes; Enable remote host re-autentication during an IKE re-key. Currently broken due to a strong swan bug
+val_help: no; Disable remote host re-authenticaton during an IKE re-key.
+val_help: inherit; Inherit the reauth configuration form your IKE-group

--- a/templates/vpn/ipsec/site-to-site/peer/node.tag/ikev2-reauth/node.def
+++ b/templates/vpn/ipsec/site-to-site/peer/node.tag/ikev2-reauth/node.def
@@ -1,7 +1,7 @@
 help: Re-authentication of the remote peer during an IKE re-key.  IKEv2 option only
 type: txt
 default: "inherit"
-syntax:expression: $VAR(@) in "yes", "no"; "must be yes, no or inherit (Default)"
+syntax:expression: $VAR(@) in "yes", "no", "inherit"; "must be yes, no or inherit (Default)"
 val_help: yes; Enable remote host re-autentication during an IKE re-key. Currently broken due to a strong swan bug
 val_help: no; Disable remote host re-authenticaton during an IKE re-key.
-val_help: inherit; Inherit the reauth configuration form your IKE-group
+val_help: inherit; Inherit the reauth configuration form your IKE-group (Default)


### PR DESCRIPTION
Bug: http://bugzilla.vyos.net/show_bug.cgi?id=395

Expose IKEv2 reauth option on the CLI, default it to 'no'.  All tunnels will inherit the reauth setting of there IKE-group by default, you can override it if needed.

IKE-group:  "vpn ipsec ike-group <name> ikev2-reauth [yes | no]
Tunnel:       "vpn ipsec site-to-site peer <peer> ikev2-reauth [yes | no | inherit]"
