### PR TITLE
Port EdgeOS auto-firewall-nat-exclude over to VyOS

### DIFF
--- a/templates/vpn/ipsec/auto-firewall-nat-exclude/node.def
+++ b/templates/vpn/ipsec/auto-firewall-nat-exclude/node.def
@@ -1,0 +1,4 @@
+type: txt
+default: "disable"
+help: Option to enable/disable auto firewall and NAT exclude (IPv4)
+syntax:expression: $VAR(@) in "enable", "disable"; "Must be enable or disable"


### PR DESCRIPTION
This option is useful if the VPN gateway is also acting as a NAT gateway for
clients behind the private network. Without this option, IPSec tunnel traffic
will not pass through successfully due to the design of netfilter

See Bugzilla #530 for tracking details.

Note this patch is independent from the strongSwan 5.x improvements.
