### PR TITLE
Add missingok to logrotate for ipsec

### DIFF
--- a/etc/logrotate.d/vyatta-ipsec-logs
+++ b/etc/logrotate.d/vyatta-ipsec-logs
@@ -1,5 +1,6 @@
 
 /var/log/vyatta/ipsec.log {
+	missingok
 	nocompress
 	size 1M
 	rotate 2


### PR DESCRIPTION
If this is not present, it causes hourly messages in /var/log/messages like this:

Mar  2 19:17:01 vyos /USR/SBIN/CRON[9140]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)
Mar  2 19:17:01 vyos /USR/SBIN/CRON[9138]: (CRON) error (grandchild #9140 failed with exit status 1)
Mar  2 19:17:01 vyos /USR/SBIN/CRON[9138]: (CRON) info (No MTA installed, discarding output)

This is because cron wants to produce output like the following when ipsec.log is not present:

/etc/cron.hourly/vyatta-logrotate-hourly:
error: stat of /var/log/vyatta/ipsec.log failed: No such file or directory
run-parts: /etc/cron.hourly/vyatta-logrotate-hourly exited with return code 1