### PR TITLE
T787: Make sure dmvpn config is generated after ipsec config. 

### DIFF
--- a/templates/vpn/node.def
+++ b/templates/vpn/node.def
@@ -2,13 +2,13 @@ priority: 900
 help: Virtual Private Network (VPN)
 end: sudo ${vyos_conf_scripts_dir}/ipsec-settings.py || exit 1
     sudo /opt/vyatta/sbin/vyatta-vti-config.pl || exit 1
+    sudo /opt/vyatta/sbin/vpn-config.pl \
+              --config_file='/etc/ipsec.conf' \
+              --secrets_file='/etc/ipsec.secrets' \
+              --init_script='/etc/init.d/ipsec' || exit 1
     sudo /opt/vyatta/sbin/dmvpn-config.pl \
               --config_file='/etc/swanctl/swanctl.conf' \
               --init_script='/etc/init.d/ipsec' || exit 1
     sudo /opt/vyatta/sbin/vyos-update-nhrp.pl --set_ipsec || exit 1
-    sudo /opt/vyatta/sbin/vpn-config.pl \
-	      --config_file='/etc/ipsec.conf' \
-              --secrets_file='/etc/ipsec.secrets' \
-              --init_script='/etc/init.d/ipsec' || exit 1
         sudo /opt/vyatta/sbin/vyatta-update-l2tp.pl || exit 1
         sudo /opt/vyatta/sbin/vyatta-update-pptp.pl || exit 1


### PR DESCRIPTION
this one needs more testing to test for breakages on ipsec.

the ipsec daemon is restarted on every change in ipsec-interface inside vpn-config.pl when this is done after the dmvpn config script has set up its config the configuration will be removed. 

This happens on initial configuration and on bootup.. this patch switches places on the two scripts so dmvpn is executed after ipsec is finished