### PR TITLE
T1499: Allow for usage of systemd interface mappings

### DIFF
--- a/templates/vpn/ipsec/site-to-site/peer/node.tag/dhcp-interface/node.def
+++ b/templates/vpn/ipsec/site-to-site/peer/node.tag/dhcp-interface/node.def
@@ -2,6 +2,6 @@ type: txt
 help: DHCP interface to listen on
 allowed:
          local -a array ;
-         array=( /var/lib/dhcp/eth* /var/lib/dhcp/br* /var/lib/dhcp/bond* ) ;
+         array=( /var/lib/dhcp/en* /var/lib/dhcp/eth* /var/lib/dhcp/br* /var/lib/dhcp/bond* ) ;
          echo  -n ${array[@]##*/}
 


### PR DESCRIPTION
This PR allows the use of systemd named interfaces for ethernet.
this might get used when migrating over to buster with systemd default mappings. 