### PR TITLE
VTI: T1291: Fix for invlid VTI interface down state

### DIFF
--- a/scripts/vti-up-down
+++ b/scripts/vti-up-down
@@ -5,15 +5,14 @@
 source /etc/default/vyatta
 source /etc/default/locale
 case "$PLUTO_VERB" in
-route-client | up-client | up-host)
+up-client | up-host)
 /bin/ip route delete default table 220
-/opt/vyatta/sbin/vyatta-vti-config.pl --updown --intf=$1 --action=up
+/opt/vyatta/sbin/vyatta-vti-config.pl --updown --intf=$1 --conn=$PLUTO_CONNECTION --action=up > /dev/null 2>&1 &
     ;;
 down-client | down-host)
-/opt/vyatta/sbin/vyatta-vti-config.pl --updown --intf=$1 --action=down 
+/opt/vyatta/sbin/vyatta-vti-config.pl --updown --intf=$1 --conn=$PLUTO_CONNECTION --action=down > /dev/null 2>&1 &
     ;;
 *)
     ;;
 esac
 exit 0
-


### PR DESCRIPTION
In case when between hosts exists two IPSec tunnels for VTI (for example, when both sides act as connection initiators), the older unused/replaced tunnel may switch VTI interface to the "down" state even if a newer IPSec connection is still in-use. Depending on other IPSec settings, this leads to a situation when VTI interfaces continuously flapping or stuck in a "down" state.
This fix is an adaptation of PR from @m-asama for the current code base. It adding new dependency from actual SA state of IPSec connection, and do not allow to switch down a VTI interface if at least one of child connections is active or try to change the state of a VTI interface to the same, as already active.