### PR TITLE
ESP: T2701: Fixed "pfs enable" option usage

### DIFF
--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -868,8 +868,10 @@ if ($vcVPN->exists('ipsec')) {
                     }
                     if (defined($pfs)) {
                         if ($pfs eq 'enable') {
+                            # Get list of IKE proposals
+                            my @ike_proposals = $vcVPN->listNodes("ipsec ike-group $ike_group proposal");
                             # Get the first IKE group's dh-group and use that as our PFS setting
-                            my $default_pfs = $vcVPN->returnValue("ipsec ike-group $ike_group proposal 1 dh-group");
+                            my $default_pfs = $vcVPN->returnValue("ipsec ike-group $ike_group proposal $ike_proposals[0] dh-group");
                             $pfs = get_dh_cipher_result($default_pfs);
                         } elsif ($pfs eq 'disable') {
                             undef $pfs;


### PR DESCRIPTION
When in ESP group configured "pfs enable" option (default behavior), PFS settings are taken from the IKE proposal 1. In case if there is no "proposal 1", this ends up with broken ESP settings and unusable VPN peer.
This fix replacing logic by taking PFS from the first one IKE proposal, regardless of its number.