### PR TITLE
vfg-vpn: T2895: Removing unnecessary duplicate check for leftsubnet

### DIFF
--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -528,10 +528,6 @@ if ($vcVPN->exists('ipsec')) {
                 $leftsubnet = '0.0.0.0/0';
             }
 
-            if (defined($leftsubnet)) {
-                $genout .= "\tleftsubnet=$leftsubnet\n";
-            }
-
             my $remotesubnet = $vcVPN->returnValue("ipsec site-to-site peer $peer $tunKeyword remote prefix");
             if ($isVti) {
                 $remotesubnet = 'any';


### PR DESCRIPTION
Removing duplicate check for "leftsubnet"
Each check generate own part for configuration "leftsubnet" therefore, in the configuration  /etc/ipsec.conf "leftsubnet" occurs 2 times.


