### PR TITLE
pre-shared-secret: T3131: Fix typo of word secret

### DIFF
--- a/templates/vpn/ipsec/site-to-site/peer/node.tag/authentication/pre-shared-secret/node.def
+++ b/templates/vpn/ipsec/site-to-site/peer/node.tag/authentication/pre-shared-secret/node.def
@@ -3,6 +3,6 @@ type: txt
 
 comp_help:
 Use of single quotes to set pre-shared secret key is recommended.  If you are
-using special characters in the pre-shared scret key then single quotes are
+using special characters in the pre-shared secret key then single quotes are
 required.
 Example usage : 'aA1-&!@,.:_2Bb'


### PR DESCRIPTION
There is typo in the spelling of "secret" mentioned in detailed information
of the pre-shared-secret key in the vpn ipsec site-to-site peer authentication
hierarchy.