### PR TITLE
IPsec: T627: Fix misuse of `vpn_die()`

### DIFF
--- a/scripts/dmvpn-config.pl
+++ b/scripts/dmvpn-config.pl
@@ -505,7 +505,7 @@ else {
 			$counter--;
 			sleep(1);
 			if($counter == 0){
-				vpn_die("$vpn_cfg_err Ipsec is not running.");
+				vpn_die(["vpn", "ipsec"], "$vpn_cfg_err IPsec is not running.\n");
 			}
 		}
 	}
@@ -522,7 +522,7 @@ else {
 			$counter--;
 			sleep(1);
 			if($counter == 0){
-				vpn_die("$vpn_cfg_err Ipsec is not running.");
+				vpn_die(["vpn", "ipsec"], "$vpn_cfg_err IPsec is not running.\n");
 			}
 		}
 	}


### PR DESCRIPTION
These two malformed calls to `vpn_die()` cause a string to be passed to `errorOutput()` in `Config.pm`, which expects an array of strings (path) and a string (error message). [T627](https://phabricator.vyos.net/T627).