### PR TITLE
cfg-vpn: T2806: Fix local prefix is source from loopback

### DIFF
--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -658,7 +658,7 @@ if ($vcVPN->exists('ipsec')) {
                     if ($remotesubnet_object == $localsubnet_object) {
                         vpn_die(["vpn","ipsec","site-to-site","peer",$peer],"$vpn_cfg_err local prefix and remote prefix cannot be the same.\n");
                     }
-                    my $check_local_route = qx(ip route show table 254 $localsubnet_object);
+                    my $check_local_route = qx(ip route show table 254 $localsubnet_object && ip route show table local $localsubnet_object);
                     if (!$check_local_route){
                         print "Warning: local prefix $localsubnet_object specified for peer \"$peer\"\n";
                         print "is not configured on any interfaces\n";


### PR DESCRIPTION
Check routes for local table
https://phabricator.vyos.net/T2806

Configuration:
```
set interfaces loopback lo address '10.21.21.1/24'
set interfaces loopback lo address '10.121.121.1/24'
set vpn ipsec esp-group ESP-GRP compression 'disable'
set vpn ipsec esp-group ESP-GRP lifetime '1800'
set vpn ipsec esp-group ESP-GRP mode 'tunnel'
set vpn ipsec esp-group ESP-GRP pfs 'enable'
set vpn ipsec esp-group ESP-GRP proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-GRP proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-GRP ikev2-reauth 'no'
set vpn ipsec ike-group IKE-GRP key-exchange 'ikev1'
set vpn ipsec ike-group IKE-GRP lifetime '3600'
set vpn ipsec ike-group IKE-GRP proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-GRP proposal 1 hash 'sha1'
set vpn ipsec ipsec-interfaces interface 'eth1'
set vpn ipsec site-to-site peer 100.64.0.1 authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer 100.64.0.1 authentication pre-shared-secret 'SeCrEt'
set vpn ipsec site-to-site peer 100.64.0.1 connection-type 'respond'
set vpn ipsec site-to-site peer 100.64.0.1 ike-group 'IKE-GRP'
set vpn ipsec site-to-site peer 100.64.0.1 local-address '100.64.0.2'
set vpn ipsec site-to-site peer 100.64.0.1 tunnel 0 allow-nat-networks 'disable'
set vpn ipsec site-to-site peer 100.64.0.1 tunnel 0 allow-public-networks 'disable'
set vpn ipsec site-to-site peer 100.64.0.1 tunnel 0 esp-group 'ESP-GRP'
set vpn ipsec site-to-site peer 100.64.0.1 tunnel 0 local prefix '10.21.21.0/24'
set vpn ipsec site-to-site peer 100.64.0.1 tunnel 0 remote prefix '10.11.11.0/24'
set vpn ipsec site-to-site peer 100.64.0.1 tunnel 1 allow-nat-networks 'disable'
set vpn ipsec site-to-site peer 100.64.0.1 tunnel 1 allow-public-networks 'disable'
set vpn ipsec site-to-site peer 100.64.0.1 tunnel 1 esp-group 'ESP-GRP'
set vpn ipsec site-to-site peer 100.64.0.1 tunnel 1 local prefix '10.121.121.0/24'
set vpn ipsec site-to-site peer 100.64.0.1 tunnel 1 remote prefix '10.111.111.0/24'

```

Before fix
```
vyos@r2-lts# commit
[ vpn ]
Warning: local prefix 10.21.21.0/24 specified for peer "100.64.0.1"
is not configured on any interfaces
Warning: local prefix 10.121.121.0/24 specified for peer "100.64.0.1"
is not configured on any interfaces

[edit]
vyos@r2-lts# 

```
It checks for routes in ip route show table 254 which doesn't show loopback routes. Adding check routes from table local.