### PR TITLE
IPsec: T4005: IKEv1 + IKEv2 in one ike-group

### DIFF
--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -723,7 +723,7 @@ if ($vcVPN->exists('ipsec')) {
                         $genout .= "\tkeyexchange=ikev2\n";
                     }
                 }else {
-                    $genout .= "\tkeyexchange=ikev1\n";
+                    $genout .= "\tkeyexchange=ike\n";
                 }
 
                 #

--- a/templates/vpn/ipsec/ike-group/node.tag/key-exchange/node.def
+++ b/templates/vpn/ipsec/ike-group/node.tag/key-exchange/node.def
@@ -1,6 +1,5 @@
-help: Key Exchange Version
+help: Key Exchange Version. If not set, both versions of IKE will be allowed (with priority to IKEv2)
 type: txt
-default: "ikev1"
 syntax:expression: $VAR(@) in "ikev1", "ikev2"; "must be ikev1 or ikev2"
-val_help: ikev1; Use IKEv1 for Key Exchange [DEFAULT]
+val_help: ikev1; Use IKEv1 for Key Exchange
 val_help: ikev2; Use IKEv2 for Key Exchange


### PR DESCRIPTION
### Change Summary
Added IKEv1 + IKEv2 in one ike-group functionality

### Types of changes
 New feature (non-breaking change which adds functionality)
### Related Task(s)
https://phabricator.vyos.net/T4005
### Component(s) name
IPsec IKE-group

### Proposed changes
both protocols are handled by Charon and connections will use 
IKEv2 when initiating, but accept any protocol version when responding.
Like in Stringswan docs:
https://wiki.strongswan.org/projects/strongswan/wiki/connsection

### How to test
Create an Ike-group without a command "key-exchange":
```
set vpn ipsec ike-group IKEgroup close-action 'none'
set vpn ipsec ike-group IKEgroup ikev2-reauth 'no'
set vpn ipsec ike-group IKEgroup lifetime '86400'
set vpn ipsec ike-group IKEgroup proposal 10 encryption 'aes256'
set vpn ipsec ike-group IKEgroup proposal 10 hash 'sha1'
set vpn ipsec ike-group IKEgroup proposal 10 dh-group '5'
``` 