### PR TITLE
dmvpn: T4092: Add new line after mobike option

### DIFF
--- a/scripts/dmvpn-config.pl
+++ b/scripts/dmvpn-config.pl
@@ -273,13 +273,13 @@ if ( $vcVPN->exists('ipsec') ) {
 				if (defined($mob_ike)) {
 					if (defined($key_exchange) && $key_exchange eq 'ikev2') {
 						if ($mob_ike eq 'enable') {
-							$genout .= "\t\tmobike = yes";
+							$genout .= "\t\tmobike = yes\n";
 						}
 						if ($mob_ike eq 'disable') {
-							$genout .= "\t\tmobike = no";
+							$genout .= "\t\tmobike = no\n";
 						}
 					}else {
-						$genout .= "\t\tmobike = no";
+						$genout .= "\t\tmobike = no\n";
 					}
 				}
 


### PR DESCRIPTION
It was missed a new line after "mobike" option for configuration DMVPN
So it generates a wrong config format for swanctl.conf
VyOS 1.2

https://phabricator.vyos.net/T4092

```
set vpn ipsec ike-group IKE-HUB mobike 'disable'
```

swanctl.conf
```
vyos@r12-lts# cat /etc/swanctl/swanctl.conf 
# generated by /opt/vyatta/sbin/dmvpn-config.pl

connections {
	dmvpn-NHRPVPN-tun0 {
		proposals = aes256-sha256-ecp521,aes256-sha256-ecp521
		version = 2
		rekey_time = 28800s
		mobike = no		keyingtries = 0
		local {

```
So `mobike + keyingtries` in one line which incorrect
