### PR TITLE
ipsec: T2922: Fix logLevel set when charon not loaded

### DIFF
--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -1295,6 +1295,21 @@ if (   $vcVPN->isDeleted('.')
         my @logmodes = $vcVPN->returnValues('ipsec logging log-modes');
         my @oldmodes = $vcVPN->returnOrigValues('ipsec logging log-modes');
         my $charonloglevel = $vcVPN->returnValue('ipsec logging log-level');
+
+        # Charon is not yet fully loaded when trying to change logLevel
+        # Set a small timeout for waiting for charon will be loaded
+        # 0 => process not found, 1 => process found
+        my $timeout = 7;
+        if (system("pgrep charon | wc -l" == 0)) {
+            while ($timeout >= 1){
+                sleep(1);
+                if (system("pgrep charon | wc -l" == 1)){
+                    last;
+                }
+                $timeout--;
+            }
+        }
+
         # Clean up any logging modes if present
         if (@oldmodes > 0) {
             foreach my $mode (@oldmodes) {


### PR DESCRIPTION
LogLevel configuration modes for ipsec are applied without any
check the state of the 'charon' process i.e at this time it tries
to apply config to not fully loaded charon process
Add checks and timeout for charon process, before executing IPSec
logging options and logging modes

https://phabricator.vyos.net/T2922

Example of configuration which should be committed without any errors
```
set interfaces ethernet eth0 address 192.0.2.2/25
set interfaces vti vti0 address 192.0.2.254/25
set vpn ipsec esp-group e1 proposal 1 encryption 'aes256'
set vpn ipsec esp-group e1 proposal 1 hash 'sha256'
set vpn ipsec ike-group i1 key-exchange 'ikev2'
set vpn ipsec ike-group i1 proposal 1 encryption 'aes256'
set vpn ipsec ike-group i1 proposal 1 hash 'sha256'
set vpn ipsec ipsec-interfaces interface 'eth0'
set vpn ipsec logging log-modes 'any'
set vpn ipsec site-to-site peer 192.0.2.1 authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer 192.0.2.1 authentication pre-shared-secret 'secret'
set vpn ipsec site-to-site peer 192.0.2.1 default-esp-group 'e1'
set vpn ipsec site-to-site peer 192.0.2.1 ike-group 'i1'
set vpn ipsec site-to-site peer 192.0.2.1 local-address '192.0.2.2'
set vpn ipsec site-to-site peer 192.0.2.1 vti bind 'vti0'
```