### PR TITLE
ipsec: T4925: Added PRF into IKE group

### DIFF
--- a/scripts/vpn-config.pl
+++ b/scripts/vpn-config.pl
@@ -683,6 +683,7 @@ if ($vcVPN->exists('ipsec')) {
                     my $encryption = $vcVPN->returnValue("ipsec ike-group $ike_group proposal $ike_proposal encryption");
                     my $hash = $vcVPN->returnValue("ipsec ike-group $ike_group proposal $ike_proposal hash");
                     my $dh_group = $vcVPN->returnValue("ipsec ike-group $ike_group proposal $ike_proposal dh-group");
+                    my $prf = $vcVPN->returnValue("ipsec ike-group $ike_group proposal $ike_proposal prf");
 
                     #
                     # Write separator if not first proposal
@@ -698,6 +699,9 @@ if ($vcVPN->exists('ipsec')) {
                     #
                     if (defined($encryption) && defined($hash)) {
                         $genout .= "$encryption-$hash";
+                        if (defined($prf) && $prf ne "") {
+                            $genout .= "-$prf";
+                        }
                         if (defined($dh_group)) {
                             my $cipher_out = get_dh_cipher_result($dh_group);
                             if ($cipher_out eq 'unknown') {

--- a/templates/vpn/ipsec/ike-group/node.tag/proposal/node.tag/prf/node.def
+++ b/templates/vpn/ipsec/ike-group/node.tag/proposal/node.tag/prf/node.def
@@ -1,0 +1,11 @@
+help: Pseudo-Random Function
+type: txt
+allowed: echo "prfmd5 prfsha1 prfaesxcbc prfaescmac prfsha256 prfsha384 prfsha512"
+syntax:expression: $VAR(@) in "prfmd5", "prfsha1", "prfsha256", "prfsha384", "prfsha512", "prfaesxcbc", "prfaescmac"; "Wrong Pseudo-Random Function"
+val_help: prfmd5; MD5 PRF
+val_help: prfsha1; SHA1 PRF
+val_help: prfsha256; SHA2_256 PRF
+val_help: prfsha384; SHA2_384 PRF
+val_help: prfsha512; SHA2_512 PRF
+val_help: prfaesxcbc; AES XCBC PRF
+val_help: prfaescmac; AES CMAC PRF


### PR DESCRIPTION
Added the possibility to configure Pseudo-Random Functions (PRF) in IKE group 
`set vpn ipsec ike-group <Ike-grp> proposal <number> prf <PRF> `
Backport from 1.4

https://vyos.dev/T4925

