### PR TITLE
ipsec: T5578: Fixed the description to "ikev2-reauth" option.

### DIFF
--- a/templates/vpn/ipsec/ike-group/node.tag/ikev2-reauth/node.def
+++ b/templates/vpn/ipsec/ike-group/node.tag/ikev2-reauth/node.def
@@ -2,5 +2,5 @@ help: Re-authentication of the remote peer during an IKE re-key.  IKEv2 option o
 type: txt
 default: "no"
 syntax:expression: $VAR(@) in "yes", "no"; "must be yes or no (Default)"
-val_help: yes; Enable remote host re-autentication during an IKE rekey. Currently broken due to a strong swan bug
+val_help: yes; Enable remote host re-autentication during an IKE rekey.
 val_help: no; Disable remote host re-authenticaton during an IKE rekey. (Default)


### PR DESCRIPTION
Removed 'Currently broken due to a strong swan bug' in the description to "ikev2-reauth" option.